### PR TITLE
Pivotal tracker reporter

### DIFF
--- a/SHDShakedownPivotalTrackerReporter.h
+++ b/SHDShakedownPivotalTrackerReporter.h
@@ -1,0 +1,18 @@
+//
+//  SHDShakedownPivotalTrackerReporter.h
+//  Shakedown
+//
+//  Created by Jean Regisser on 4/26/13.
+//  Copyright (c) 2013 Jean Regisser. All rights reserved.
+//
+
+#import "SHDShakedownReporter.h"
+
+@interface SHDShakedownPivotalTrackerReporter : SHDShakedownReporter
+
+@property (nonatomic, copy) NSString *apiURL;
+@property (nonatomic, copy) NSString *token;
+@property (nonatomic, copy) NSString *projectID;
+@property (nonatomic, copy) NSString *labels;
+
+@end

--- a/SHDShakedownPivotalTrackerReporter.m
+++ b/SHDShakedownPivotalTrackerReporter.m
@@ -1,0 +1,135 @@
+//
+//  SHDShakedownPivotalTrackerReporter.m
+//  Shakedown
+//
+//  Created by Jean Regisser on 4/26/13.
+//  Copyright (c) 2013 Jean Regisser. All rights reserved.
+//
+
+#import "SHDShakedownPivotalTrackerReporter.h"
+#import "SHDXMLReader.h"
+
+static NSString * const kSHDTrackerTokenHeaderField = @"X-TrackerToken";
+
+// This replicates `AFPercentEscapedQueryStringPairMemberFromStringWithEncoding`.
+static NSString * SHDPercentEscapedQueryStringFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
+    static NSString * const kSHDCharactersToBeEscaped = @":/?&=;+!@#$()~";
+    static NSString * const kSHDCharactersToLeaveUnescaped = @"[].";
+    
+    return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)kSHDCharactersToLeaveUnescaped, (__bridge CFStringRef)kSHDCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
+}
+
+@implementation SHDShakedownPivotalTrackerReporter
+
+- (id)init {
+    self = [super init];
+    if (self) {
+        self.apiURL = @"http://www.pivotaltracker.com/services/v3";
+    }
+    return self;
+}
+
+- (void)sendAsynchronousXMLRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLResponse *response, NSData *data, NSDictionary *xmlDictionary, NSError *error))handler {
+    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+        NSError* returnError = error;
+        NSDictionary* xmlDictionary = nil;
+
+        NSString *contentType = response.MIMEType;
+        if (!returnError && data.length && [[NSSet setWithObjects:@"application/xml", @"text/xml", nil] containsObject:contentType]) {
+            xmlDictionary = [SHDXMLReader dictionaryForXMLData:data error:&returnError];
+        }
+
+        handler(response, data, xmlDictionary, returnError);
+    }];
+}
+
+- (void)addAttachment:(id)attachmentData toStoryID:(NSString *)storyID completionHandler:(void (^)(NSURLResponse *response, NSData *data, NSDictionary *xmlDictionary, NSError *error))handler {
+    NSDictionary *attachments = @{ @"Filedata": attachmentData };
+	
+    NSString *boundary = @"0xKhTmLbOuNdArY";
+    NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary];
+	
+    NSURL *postURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/projects/%@/stories/%@/attachments", self.apiURL, self.projectID, storyID]];
+    NSMutableURLRequest *postRequest = [NSMutableURLRequest requestWithURL:postURL];
+    [postRequest setTimeoutInterval:120.0]; // Upload can take some time on slower connections
+    NSData* body = [self httpBodyDataForDictionary:nil attachments:attachments boundary:boundary];
+    [postRequest setHTTPBody:body];
+    [postRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
+    [postRequest setHTTPMethod:@"POST"];
+    [postRequest setValue:self.token forHTTPHeaderField:kSHDTrackerTokenHeaderField];
+    [self sendAsynchronousXMLRequest:postRequest completionHandler:handler];
+}
+
+- (NSInteger)statusCodeForResponse:(NSURLResponse *)response {
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+        NSHTTPURLResponse *resp = (NSHTTPURLResponse *)response;
+        return resp.statusCode;
+    }
+	
+    return NSNotFound;
+}
+
+- (void)reportBug:(SHDBugReport *)bugReport {
+    NSMutableArray* queryParams = [NSMutableArray array];
+    [queryParams addObject:@"story[story_type]=bug"];
+    if (bugReport.title.length) {
+        [queryParams addObject:[NSString stringWithFormat:@"story[name]=%@",
+        SHDPercentEscapedQueryStringFromStringWithEncoding(bugReport.title, NSUTF8StringEncoding)]];
+    }
+    if (bugReport.formattedReport.length) {
+        [queryParams addObject:[NSString stringWithFormat:@"story[description]=%@",
+        SHDPercentEscapedQueryStringFromStringWithEncoding(bugReport.formattedReport, NSUTF8StringEncoding)]];
+    }
+    if (self.labels.length) {
+        [queryParams addObject:[NSString stringWithFormat:@"story[labels]=%@",
+        SHDPercentEscapedQueryStringFromStringWithEncoding(self.labels, NSUTF8StringEncoding)]];
+    }
+	
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/projects/%@/stories?%@", self.apiURL, self.projectID, [queryParams componentsJoinedByString:@"&"]]];
+    NSMutableURLRequest *addStoryRequest = [NSMutableURLRequest requestWithURL:url];
+    [addStoryRequest setHTTPMethod:@"POST"];
+    [addStoryRequest setValue:self.token forHTTPHeaderField:kSHDTrackerTokenHeaderField];
+	
+    __weak SHDShakedownPivotalTrackerReporter *weakSelf = self;
+	
+    [self sendAsynchronousXMLRequest:addStoryRequest completionHandler:^(NSURLResponse *response, NSData *data, NSDictionary *xmlDictionary, NSError *error) {
+        __strong SHDShakedownPivotalTrackerReporter *strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+    
+        if (error) {
+            [strongSelf.delegate shakedownFailedToFileBug:[NSString stringWithFormat:@"Could not create bug on Pivotal: %@", error.localizedDescription]];
+        } else {
+            NSString *storyID = [xmlDictionary valueForKeyPath:@"story.id.text"];
+            NSString *storyURL = [xmlDictionary valueForKeyPath:@"story.url.text"];
+      
+            if ([strongSelf statusCodeForResponse:response] == 200 && storyID.length) {
+                [self addAttachment:bugReport.screenshots[0] toStoryID:storyID completionHandler:^(NSURLResponse *response, NSData *data, NSDictionary *xmlDictionary, NSError *error) {
+                    __strong SHDShakedownPivotalTrackerReporter *strongSelf = weakSelf;
+                    if (!strongSelf) { return; }
+
+                    if (error) {
+                        [strongSelf.delegate shakedownFailedToFileBug:[NSString stringWithFormat:@"Could not add attachment on Pivotal: %@", error.localizedDescription]];
+                    } else {
+                        NSString *attachmentID = [xmlDictionary valueForKeyPath:@"attachment.id.text"];
+
+                        if ([strongSelf statusCodeForResponse:response] == 200 && attachmentID.length) {
+                            [strongSelf.delegate shakedownFiledBugSuccessfullyWithLink:[NSURL URLWithString:storyURL]];
+                        } else {
+                            // Assume data is encoded in UTF8 (even if it might be wrong)
+                            [strongSelf.delegate shakedownFailedToFileBug:
+                            [NSString stringWithFormat:@"Could not add attachment on Pivotal: invalid response ('%@')",
+                            [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]]];
+                        }
+                    }
+                }];
+            } else {
+                // Assume data is encoded in UTF8 (even if it might be wrong)
+                [strongSelf.delegate shakedownFailedToFileBug:
+                [NSString stringWithFormat:@"Could not create bug on Pivotal: invalid response ('%@')",
+                [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]]];
+            }
+        }
+    }];
+}
+
+@end

--- a/SHDShakedownPivotalTrackerReporter.m
+++ b/SHDShakedownPivotalTrackerReporter.m
@@ -24,7 +24,7 @@ static NSString * SHDPercentEscapedQueryStringFromStringWithEncoding(NSString *s
 - (id)init {
     self = [super init];
     if (self) {
-        self.apiURL = @"http://www.pivotaltracker.com/services/v3";
+        self.apiURL = @"https://www.pivotaltracker.com/services/v3";
     }
     return self;
 }

--- a/SHDShakedownReporter.m
+++ b/SHDShakedownReporter.m
@@ -27,8 +27,8 @@
     
     NSMutableData *body = [NSMutableData data];
     
-    NSData *initialBoundary = [NSString stringWithFormat:@"--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *encapsulationBoundary = [NSString stringWithFormat:@"\r\n--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *initialBoundary = [[NSString stringWithFormat:@"--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *encapsulationBoundary = [[NSString stringWithFormat:@"\r\n--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding];
     
     for (NSString *key in dictionary) {
         id value = dictionary[key];

--- a/SHDShakedownReporter.m
+++ b/SHDShakedownReporter.m
@@ -27,11 +27,15 @@
     
     NSMutableData *body = [NSMutableData data];
     
+    NSData *initialBoundary = [NSString stringWithFormat:@"--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *encapsulationBoundary = [NSString stringWithFormat:@"\r\n--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding];
+    
     for (NSString *key in dictionary) {
         id value = dictionary[key];
         if ([value isKindOfClass:[NSString class]]) {
             NSString *stringValue = (NSString *)value;
-            [body appendData:[[NSString stringWithFormat:@"\r\n--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+            [body appendData:initialBoundary ?: encapsulationBoundary];
+            initialBoundary = nil;
             [body appendData:[[NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"\r\n\r\n", key] dataUsingEncoding:NSUTF8StringEncoding]];
             [body appendData:[[NSString stringWithFormat:@"%@", stringValue] dataUsingEncoding:NSUTF8StringEncoding]];
         } else {
@@ -43,12 +47,14 @@
         id value = attachments[key];
         if ([value isKindOfClass:[NSString class]]) {
             NSString *stringValue = (NSString *)value;
-            [body appendData:[[NSString stringWithFormat:@"\r\n--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+            [body appendData:initialBoundary ?: encapsulationBoundary];
+            initialBoundary = nil;
             [body appendData:[[NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@.txt\"\r\n", key, key] dataUsingEncoding:NSUTF8StringEncoding]];
             [body appendData:[@"Content-Type: text/plain\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
             [body appendData:[[NSString stringWithFormat:@"%@", stringValue] dataUsingEncoding:NSUTF8StringEncoding]];
         } else if ([value isKindOfClass:[UIImage class]]) {
-            [body appendData:[[NSString stringWithFormat:@"\r\n--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+            [body appendData:initialBoundary ?: encapsulationBoundary];
+            initialBoundary = nil;
             [body appendData:[[NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"; filename=\"%@.png\"\r\n", key, key] dataUsingEncoding:NSUTF8StringEncoding]];
             [body appendData:[@"Content-Type: image/png\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
             [body appendData:UIImagePNGRepresentation(value)];
@@ -57,7 +63,7 @@
         }
     }
     
-    
+    // Final boundary
     [body appendData:[[NSString stringWithFormat:@"\r\n--%@--\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
     
     return body;

--- a/SHDXMLReader.h
+++ b/SHDXMLReader.h
@@ -1,0 +1,122 @@
+//
+//  SHDXMLReader.h
+//  Shakedown
+//
+// Adapted from https://github.com/genkernel/XML-to-NSDictionary
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+//
+// http://troybrant.net/blog/2010/09/simple-xml-to-nsdictionary-converter/
+//
+// Parse the XML into a dictionary
+// NSError *parseError = nil;
+// NSDictionary *xmlDictionary = [SHDXMLReader dictionaryForXMLString:testXMLString error:&parseError];
+// 
+// // Print the dictionary
+// NSLog(@"%@", xmlDictionary);
+//
+// testXMLString = 
+//    <items>
+//        <item id=”0001″ type=”donut”>
+//            <name>Cake</name>
+//            <ppu>0.55</ppu>
+//            <batters>
+//                <batter id=”1001″>Regular</batter>
+//                <batter id=”1002″>Chocolate</batter>
+//                <batter id=”1003″>Blueberry</batter>
+//            </batters>
+//            <topping id=”5001″>None</topping>
+//            <topping id=”5002″>Glazed</topping>
+//            <topping id=”5005″>Sugar</topping>
+//        </item>
+//    </items>
+//
+// is converted into
+//
+// xmlDictionary = {
+//     items = {
+//         item = {
+//             attributes = {
+//                 id = 0001;
+//                 type = donut;
+//             },
+//             name = {
+//                 text = Cake;
+//             };
+//             ppu = {
+//                 text = 0.55;
+//             };
+//             batters = {
+//                 batter = (
+//                 {
+//                     attributes = {
+//                         id = 1001;
+//                     },
+//                     text = Regular;
+//                 },
+//                 {
+//                     attributes = {
+//                         id = 1002;
+//                     },
+//                     text = Chocolate;
+//                 },
+//                 {
+//                     attributes = {
+//                         id = 1003;
+//                     },
+//                     text = Blueberry;
+//                 }
+//                 );
+//             };
+//             topping = (
+//             {
+//                 attributes = {
+//                     id = 5001;
+//                 },
+//                 text = None;
+//             },
+//             {
+//                 attributes = {
+//                     id = 5002;
+//                 },
+//                 text = Glazed;
+//             },
+//             {
+//                 attributes = {
+//                     id = 5005;
+//                 },
+//                 text = Sugar;
+//             }
+//             );
+//         };
+//     };
+// }
+
+
+@interface SHDXMLReader : NSObject<NSXMLParserDelegate>
+
++ (NSDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError **)error;
++ (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError **)error;
+
+@end
+
+extern NSString * const kSHDXMLReaderAttributesNodeKey = @"attributes";
+extern NSString * const kSHDXMLReaderTextNodeKey = @"text";

--- a/SHDXMLReader.h
+++ b/SHDXMLReader.h
@@ -2,25 +2,25 @@
 //  SHDXMLReader.h
 //  Shakedown
 //
-// Adapted from https://github.com/genkernel/XML-to-NSDictionary
+//  Adapted from https://github.com/genkernel/XML-to-NSDictionary
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 // 
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 //

--- a/SHDXMLReader.h
+++ b/SHDXMLReader.h
@@ -118,5 +118,5 @@
 
 @end
 
-extern NSString * const kSHDXMLReaderAttributesNodeKey = @"attributes";
-extern NSString * const kSHDXMLReaderTextNodeKey = @"text";
+extern NSString * const kSHDXMLReaderAttributesNodeKey;
+extern NSString * const kSHDXMLReaderTextNodeKey;

--- a/SHDXMLReader.m
+++ b/SHDXMLReader.m
@@ -1,0 +1,151 @@
+//
+//  SHDXMLReader.m
+//  Shakedown
+//
+//  Adapted from https://github.com/genkernel/XML-to-NSDictionary
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+// 
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+// 
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "SHDXMLReader.h"
+
+NSString * const kSHDXMLReaderAttributesNodeKey = @"attributes";
+NSString * const kSHDXMLReaderTextNodeKey = @"text";
+
+@interface SHDXMLReader ()
+
+@property (strong, nonatomic) NSMutableArray *dictionaryStack;
+@property (strong, nonatomic) NSMutableString *textInProgress;
+@property (assign, nonatomic) NSError *__autoreleasing *error;
+ 
+@end
+
+@interface SHDXMLReader (Internal)
+
+- (NSDictionary *)objectWithData:(NSData *)data;
+
+@end
+
+
+@implementation SHDXMLReader
+
+#pragma mark -
+#pragma mark Public methods
+
++ (NSDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError **)errorPointer {
+    SHDXMLReader *reader = [SHDXMLReader new];
+    reader.error = errorPointer;
+    return [reader objectWithData:data];
+}
+
++ (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError **)errorPointer {
+    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+    return [SHDXMLReader dictionaryForXMLData:data error:errorPointer];
+}
+
+#pragma mark -
+#pragma mark Parsing
+
+- (NSDictionary *)objectWithData:(NSData *)data {
+    self.dictionaryStack = [[NSMutableArray alloc] init];
+    self.textInProgress = [[NSMutableString alloc] init];
+    
+    // Initialize the stack with a fresh dictionary
+    [self.dictionaryStack addObject:[NSMutableDictionary dictionary]];
+    
+    // Parse the XML
+    NSXMLParser *parser = [[NSXMLParser alloc] initWithData:data];
+    parser.delegate = self;
+    BOOL success = [parser parse];
+    
+    // Return the stack's root dictionary on success
+    if (success) {
+        NSDictionary *resultDict = [self.dictionaryStack objectAtIndex:0];
+        return resultDict;
+    }
+    
+    return nil;
+}
+
+#pragma mark -
+#pragma mark NSXMLParserDelegate methods
+
+- (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict {
+    // Get the dictionary for the current level in the stack
+    NSMutableDictionary *parentDict = [self.dictionaryStack lastObject];
+
+    // Create the child dictionary for the new element, and initilaize it with the attributes
+    NSMutableDictionary *childDict = [NSMutableDictionary dictionary];
+    [childDict addEntriesFromDictionary:attributeDict];
+    
+    // If there's already an item for this key, it means we need to create an array
+    id existingValue = [parentDict objectForKey:elementName];
+    if (existingValue) {
+        NSMutableArray *array = nil;
+        if ([existingValue isKindOfClass:[NSMutableArray class]]) {
+            // The array exists, so use it
+            array = (NSMutableArray *) existingValue;
+        } else {
+            // Create an array if it doesn't exist
+            array = [NSMutableArray array];
+            [array addObject:existingValue];
+
+            // Replace the child dictionary with an array of children dictionaries
+            [parentDict setObject:array forKey:elementName];
+        }
+        
+        // Add the new child dictionary to the array
+        [array addObject:childDict];
+    } else {
+        // No existing value, so update the dictionary
+        [parentDict setObject:childDict forKey:elementName];
+    }
+    
+    // Update the stack
+    [self.dictionaryStack addObject:childDict];
+}
+
+- (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName {
+    // Update the parent dict with text info
+    NSMutableDictionary *dictInProgress = [self.dictionaryStack lastObject];
+    
+    // Set the text property
+    if (self.textInProgress.length > 0) {
+        [dictInProgress setObject:[self.textInProgress stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]
+            forKey:kSHDXMLReaderTextNodeKey];
+    
+        // Reset the text
+        self.textInProgress = [[NSMutableString alloc] init];
+    }
+    
+    // Pop the current dict
+    [self.dictionaryStack removeLastObject];
+}
+
+- (void)parser:(NSXMLParser *)parser foundCharacters:(NSString *)string {
+    // Build the text value
+    [self.textInProgress appendString:string];
+}
+
+- (void)parser:(NSXMLParser *)parser parseErrorOccurred:(NSError *)parseError {
+    // Set the error pointer to the parser's error object
+    (*self.error) = parseError;
+}
+
+@end


### PR DESCRIPTION
Hi,

I've implemented a Pivotal Tracker reporter.

I've found and fixed a bug in [httpBodyDataForDictionary](https://github.com/jeanregisser/Shakedown/commit/b1f331a24c4f13514fc1046dfbeaa75994ed7f19).

I added a simple generic XML parser that could be reused for other reporters.
The code of the XML parser was adapted from https://github.com/genkernel/XML-to-NSDictionary. I've added proper attributions to the SHDXMLReader.[h|m] files.

Also we might want to move [SHDPercentEscapedQueryStringFromStringWithEncoding](https://github.com/jeanregisser/Shakedown/pull/new/pivotal_tracker_reporter#L1R15) to the base reporter class so that it can be reused.

Let me know what you think.
