### PR TITLE
Add ability to attach any type of attachments in a bug report

### DIFF
--- a/SHDAttachment.h
+++ b/SHDAttachment.h
@@ -1,0 +1,21 @@
+//
+//  SHDAttachment.h
+//  Shakedown
+//
+//  Created by Jean Regisser on 5/7/13.
+//  Copyright (c) 2013 Jean Regisser. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SHDAttachment : NSObject
+
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) NSString *fileName;
+@property (nonatomic, strong) NSString *mimeType;
+@property (nonatomic, strong) NSData *data;
+
++ (SHDAttachment*)attachmentWithName:(NSString *)name fileName:(NSString *)fileName
+                            mimeType:(NSString *)mimeType data:(NSData *)data;
+
+@end

--- a/SHDAttachment.m
+++ b/SHDAttachment.m
@@ -1,0 +1,23 @@
+//
+//  SHDAttachment.m
+//  Shakedown
+//
+//  Created by Jean Regisser on 5/7/13.
+//  Copyright (c) 2013 Jean Regisser. All rights reserved.
+//
+
+#import "SHDAttachment.h"
+
+@implementation SHDAttachment
+
++ (SHDAttachment *)attachmentWithName:(NSString *)name fileName:(NSString *)fileName
+                            mimeType:(NSString *)mimeType data:(NSData *)data {
+    SHDAttachment *attachment = [[self alloc] init];
+    attachment.name = name;
+    attachment.fileName = fileName;
+    attachment.mimeType = mimeType;
+    attachment.data = data;
+    return attachment;
+}
+
+@end

--- a/SHDBugReport.h
+++ b/SHDBugReport.h
@@ -23,4 +23,6 @@
 
 @property (nonatomic, readonly) NSString *formattedReport;
 
+@property (nonatomic, strong) NSMutableArray *attachments; // Array of SHDAttachment
+
 @end

--- a/SHDShakedownEmailReporter.m
+++ b/SHDShakedownEmailReporter.m
@@ -8,6 +8,7 @@
 
 #import "SHDShakedownEmailReporter.h"
 #import <MessageUI/MessageUI.h>
+#import "SHDAttachment.h"
 
 @interface SHDShakedownEmailReporter () <MFMailComposeViewControllerDelegate>
 
@@ -20,10 +21,9 @@
 - (void)reportBug:(SHDBugReport *)bugReport {
     self.composer = [[MFMailComposeViewController alloc] initWithNibName:nil bundle:nil];
     [self.composer setSubject:bugReport.title];
-    for (UIImage *screenshot in bugReport.screenshots) {
-        [self.composer addAttachmentData:UIImagePNGRepresentation(screenshot) mimeType:@"img/png" fileName:@"screenshot.png"];
+    for (SHDAttachment *attachment in [self allAttachmentsForBugReport:bugReport]) {
+        [self.composer addAttachmentData:attachment.data mimeType:attachment.mimeType fileName:attachment.fileName];
     }
-    [self.composer addAttachmentData:[bugReport.log dataUsingEncoding:NSUTF8StringEncoding] mimeType:@"text/plain" fileName:@"log.txt"];
     [self.composer setMessageBody:bugReport.formattedReport isHTML:NO];
     if (self.recipient) {
         [self.composer setToRecipients:@[self.recipient]];

--- a/SHDShakedownReporter.h
+++ b/SHDShakedownReporter.h
@@ -17,6 +17,8 @@
 
 @end
 
+@class SHDAttachment;
+
 @interface SHDShakedownReporter : NSObject
 
 @property (nonatomic, weak) id <SHDShakedownReporterDelegate> delegate;
@@ -24,9 +26,13 @@
 
 - (void)reportBug:(SHDBugReport *)bugReport;
 
+- (NSArray *)attachmentsForScreenshots:(NSArray *)screenshots; /** Create array of SHDAttachment with PNG data from the array of UIImage */
+- (SHDAttachment *)attachmentForLog:(NSString *)log; /** Create a SHDAttachment from the log */
+- (NSArray *)allAttachmentsForBugReport:(SHDBugReport*)bugReport; /** Create an array of SHDAttachment from the screenshot, log and attachment for the SHDBugReport */
+
 - (NSString *)base64StringFromString:(NSString *)string;
 - (NSString *)base64StringFromData:(NSData *)data;
 
-- (NSData *)httpBodyDataForDictionary:(NSDictionary *)dictionary attachments:(NSDictionary *)attachments boundary:(NSString *)boundary;
+- (NSData *)httpBodyDataForDictionary:(NSDictionary *)dictionary attachments:(NSArray *)attachments boundary:(NSString *)boundary;
 
 @end

--- a/SHDShakedownYouTrackReporter.m
+++ b/SHDShakedownYouTrackReporter.m
@@ -41,8 +41,7 @@
                                         @"summary": bugReport.title,
                                         @"description": bugReport.formattedReport
                                         };
-            NSDictionary *attachments = @{@"screenshot": bugReport.screenshots[0],
-                                          @"log": bugReport.log};
+            NSArray *attachments = [self allAttachmentsForBugReport:bugReport];
             
             NSString *boundary = @"0xKhTmLbOuNdArY";
             NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary];


### PR DESCRIPTION
Hi again,

In my apps I would like to upload additional files with bug reports (for instance custom data generated by the app).

Here's a draft of what I see:

``` objc
@interface SHDBugReport : NSObject

@property (nonatomic, strong) NSString *title;
@property (nonatomic, strong) NSString *generalDescription;
@property (nonatomic, strong) NSString *reproducability;
@property (nonatomic, strong) NSArray *steps;
@property (nonatomic, strong) NSMutableArray *screenshots;

@property (nonatomic, strong) NSDictionary *userInformation;
@property (nonatomic, readonly) NSDictionary *deviceDictionary;

@property (nonatomic, strong) NSString *log;

@property (nonatomic, readonly) NSString *formattedReport;

@property (nonatomic, readonly) NSArray *attachments; // Array of SHDAttachment

- (void)appendAttachmentWithData:(NSData *)data
                          name:(NSString *)name
                      fileName:(NSString *)fileName
                      mimeType:(NSString *)mimeType;

@end

@interface SHDAttachment : NSObject

@property (nonatomic, strong) NSString *name;
@property (nonatomic, strong) NSString *fileName;
@property (nonatomic, strong) NSString *mimeType;
@property (nonatomic, strong) NSData *data;

@end
```

In fact `log` and `screenshots` would be added to the attachments array.

Then all reporters would simply process all attachments and upload them on the service if it's supported.

What do you think?
