### PR TITLE
[arm64] fixed arm64 missing UIGetScreenImage hidden definition

### DIFF
--- a/Classes/Models/SHDBugReport.m
+++ b/Classes/Models/SHDBugReport.m
@@ -106,7 +106,23 @@
 }
 
 #if defined(DEBUG) || defined(ADHOC)
+#if __LP64__ || (TARGET_OS_EMBEDDED && !TARGET_OS_IPHONE) || TARGET_OS_WIN32 || NS_BUILD_32_LIKE_64
+CGImageRef UIGetScreenImage(void) {
+    UIGraphicsBeginImageContextWithOptions([UIScreen mainScreen].bounds.size, NO, 0);
+
+    for (UIWindow *window in [UIApplication sharedApplication].windows) {
+        [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];
+    }
+    
+    UIImage *copied = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return [copied CGImage];
+}
+#else
 CGImageRef UIGetScreenImage(void);
+#endif
+
 #endif
 
 @end


### PR DESCRIPTION
# Why

Shakedown would fail to compile on arm64 builds.
# Fix

This fixes the missing `UIGetScreenImage` declaration/definition on the arm64 architecture. 
We used the now ios7 native `drawViewHierarchyInRect:` method only for devices that don't already support  the hidden call to `UIGetScreenImage`
